### PR TITLE
Make admin roles configurable

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,8 @@ class ApplicationController < ActionController::Base
   end
 
   def admin_role?
-    current_voter&.email&.split('@')&.last == 'civio.es'
+    roles = Admin::Role.all.pluck(:email)
+    roles.any?{ |role| current_voter&.email&.include?(role) }
   end
 
   def sign_in(voter)

--- a/app/models/admin/role.rb
+++ b/app/models/admin/role.rb
@@ -1,0 +1,5 @@
+module Admin
+  class Role < ApplicationRecord
+    validates :email, format: /@/
+  end
+end

--- a/db/migrate/20170503055801_create_roles.rb
+++ b/db/migrate/20170503055801_create_roles.rb
@@ -1,0 +1,8 @@
+class CreateRoles < ActiveRecord::Migration[5.0]
+  def change
+    create_table :roles do |t|
+      t.string :email, null: false
+    end
+    add_index :roles, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161015192020) do
+ActiveRecord::Schema.define(version: 20170503055801) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,11 @@ ActiveRecord::Schema.define(version: 20161015192020) do
     t.index ["proposal_id"], name: "index_proposals_voters_on_proposal_id", using: :btree
     t.index ["voter_id", "proposal_id"], name: "index_proposals_voters_on_voter_id_and_proposal_id", unique: true, using: :btree
     t.index ["voter_id"], name: "index_proposals_voters_on_voter_id", using: :btree
+  end
+
+  create_table "roles", force: :cascade do |t|
+    t.string "email", null: false
+    t.index ["email"], name: "index_roles_on_email", unique: true, using: :btree
   end
 
   create_table "voters", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,9 @@
 ### Sample development data
 
+## Admin roles
+
+civio = Admin::Role.create(email: '@civio.es')
+
 ## Voters
 
 raul    = Voter.create(email: 'raul@civio.es', verified: true)

--- a/test/fixtures/admin/roles.yml
+++ b/test/fixtures/admin/roles.yml
@@ -1,0 +1,4 @@
+# Admin Roles
+
+civio:
+    email: '@civio.es'

--- a/test/models/admin/role_test.rb
+++ b/test/models/admin/role_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class Admin::RoleTest < ActiveSupport::TestCase
+  def some_valid_email; "someone@some.tld"; end
+  def some_invalid_email; "someone.some.tld"; end
+  def some_valid_domain; "@someone.some.tld"; end
+
+  setup do
+    @role = Admin::Role.new(email: some_valid_email)
+  end
+
+  test "should be valid" do
+    assert @role.valid?
+  end
+
+  test "email should be valid" do
+    @role.email = some_invalid_email
+    assert_not @role.valid?
+  end
+
+  test "email shouldn't be blank" do
+    @role.email = blank
+    assert_not @role.valid?
+  end
+
+  test "email can be just a domain" do
+    @role.email = some_valid_domain
+    assert @role.valid?
+  end
+end


### PR DESCRIPTION
Our preference was in the line of having the configuration of the admin roles to be a part of the deployment process, but it seems that having the info in the database would be more practical.

An admin role will be defined by an specific email (e.g 'eduardo@civio.es') or by a domain (e.g '@civio.es')

A sample domain based role has been added to the database seeds, and the admin zone panel will include the functionality to add/update/delete the roles.