### PR TITLE
Add support for voter secrets validation

### DIFF
--- a/app/actions/register_voter.rb
+++ b/app/actions/register_voter.rb
@@ -1,10 +1,10 @@
 class RegisterVoter
-  def self.call(email)
-    new(email).call
+  def self.call(email, secret={})
+    new(email, secret).call
   end
 
   def call
-    return nil unless @voter.persisted?
+    return nil unless (@voter.persisted? && valid_secret?)
     @voter.generate_verification_token!
     VoterMailer.voter_verification_email(@voter).deliver
     @voter
@@ -12,7 +12,17 @@ class RegisterVoter
 
   private
 
-  def initialize(email)
+  def initialize(email, secret)
     @voter = Voter.find_or_create_by(email: email)
+    @secret = VoterSecret.find_by("data = :data", data: hstore(secret))
+  end
+
+  def hstore(hash)
+    hash.to_s[1...-1]
+  end
+
+  def valid_secret?
+    return true if VoterSecret.list_of_secrets.empty?
+    !@secret.nil?
   end
 end

--- a/app/controllers/voters_controller.rb
+++ b/app/controllers/voters_controller.rb
@@ -5,8 +5,9 @@ class VotersController < ApplicationController
   end
 
   def create
-    email = params[:voter][:email]
-    if RegisterVoter.call(email)
+    email = voter_params[:email]
+    secret = voter_secret_params[:secret_data].to_h
+    if RegisterVoter.call(email,secret)
       session[:verification_pending] = true
       redirect_to current_redirect!, notice: "We've sent you a <strong>verification token</strong>, please see your inbox for further instructions"
     else
@@ -43,5 +44,14 @@ class VotersController < ApplicationController
     session.delete(:verification_pending)
     sign_in(@voter)
     redirect_to current_redirect!, success: "<strong>Successfully verified</strong>, you can now take part in the participatory budgeting process"
+  end
+
+  def voter_params
+    params.require(:voter).permit(:email)
+  end
+
+  def voter_secret_params
+    return ActionController::Parameters.new({}) unless (params[:voter] && params[:voter][:secret_data])
+    params.require(:voter).permit(secret_data: params[:voter][:secret_data].try(:keys))
   end
 end

--- a/app/models/voter_secret.rb
+++ b/app/models/voter_secret.rb
@@ -1,0 +1,11 @@
+class VoterSecret < ApplicationRecord
+  store_accessor :data
+
+  def self.list_of_secrets
+    query = <<~EOQ
+      SELECT distinct skeys(data) FROM voter_secrets;
+    EOQ
+
+    VoterSecret.connection.execute(query).values.flatten
+  end
+end

--- a/app/views/voters/new.html.haml
+++ b/app/views/voters/new.html.haml
@@ -9,4 +9,9 @@
             .form-group
               = f.label 'Email address'
               = f.text_field :email, class: 'form-control'
+              = f.fields_for :secret_data do |df|
+                - VoterSecret.list_of_secrets.each do |secret|
+                  .form-group
+                  = df.label secret.humanize
+                  = df.text_field secret.to_sym, class: 'form-control'
             = f.submit 'Email me a link to sign in', class: 'btn btn-primary'

--- a/db/migrate/20170515141121_enable_hstore_extension.rb
+++ b/db/migrate/20170515141121_enable_hstore_extension.rb
@@ -1,0 +1,5 @@
+class EnableHstoreExtension < ActiveRecord::Migration[5.0]
+  def change
+    enable_extension 'hstore'
+  end
+end

--- a/db/migrate/20170515141122_create_voter_secrets.rb
+++ b/db/migrate/20170515141122_create_voter_secrets.rb
@@ -1,0 +1,10 @@
+class CreateVoterSecrets < ActiveRecord::Migration[5.0]
+  def change
+    create_table :voter_secrets do |t|
+      t.hstore :data, null: false, default: {}
+
+      t.timestamps
+    end
+    add_index :voter_secrets, :data, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170503055801) do
+ActiveRecord::Schema.define(version: 20170515141122) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "hstore"
 
   create_table "campaigns", force: :cascade do |t|
     t.string   "title",                                                null: false
@@ -75,6 +76,13 @@ ActiveRecord::Schema.define(version: 20170503055801) do
   create_table "roles", force: :cascade do |t|
     t.string "email", null: false
     t.index ["email"], name: "index_roles_on_email", unique: true, using: :btree
+  end
+
+  create_table "voter_secrets", force: :cascade do |t|
+    t.hstore   "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["data"], name: "index_voter_secrets_on_data", using: :gin
   end
 
   create_table "voters", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -226,3 +226,12 @@ lane_3  = Proposal.create(
               Having a dedicated bike lane will improve security and make the trip more enjoyable.
             EOD
           )
+
+## Voter secrets
+
+local_1    = VoterSecret.create(data: { document: '53713184D', birth_date: '1974-11-29' })
+local_2    = VoterSecret.create(data: { document: '279793B', birth_date: '1986-10-19' })
+resident_1 = VoterSecret.create(data: { document: 'X07323369A', birth_date: '1945-11-06' })
+resident_2 = VoterSecret.create(data: { document: 'Y01927564M', birth_date: '1945-11-06' })
+foreign_1  = VoterSecret.create(data: { document: '423994F', birth_date: '1990-05-12'})
+foreign_2  = VoterSecret.create(data: { document: '08-VU-2160/16', birth_date: '1998-11-02' })

--- a/test/actions/register_voter_test.rb
+++ b/test/actions/register_voter_test.rb
@@ -3,24 +3,47 @@ require 'test_helper'
 class RegisterVoterTest < ActiveSupport::TestCase
   def some_valid_email; "someone@some.tld"; end
   def some_invalid_email; "someone.some.tld"; end
+  def some_valid_secret; voter_secrets(:some_voter_secret).data; end
+  def some_invalid_secret; VoterSecret.new.data; end
 
   setup do
     ApplicationMailer.deliveries.clear
   end
 
   test "with invalid email voter shouldn't be registered" do
-    voter = RegisterVoter.call(some_invalid_email)
+    voter = RegisterVoter.call(some_invalid_email, some_valid_secret)
     assert_not voter
   end
 
-  test "with valid email voter should be registered and verification token should be generated" do
-    voter = RegisterVoter.call(some_valid_email)
+  test "with invalid secret voter shouldn't be registered" do
+    voter = RegisterVoter.call(some_valid_email, some_invalid_secret)
+    assert_not voter
+  end
+
+  test "with valid email and secret voter should be registered and verification token should be generated" do
+    voter = RegisterVoter.call(some_valid_email, some_valid_secret)
     assert voter.verification_token
   end
 
   test "verification email should be sent when the voter is registered" do
     assert_difference('ApplicationMailer.deliveries.size', 1) do
-      RegisterVoter.call(some_valid_email)
+      RegisterVoter.call(some_valid_email, some_valid_secret)
     end
+  end
+
+  test "with valid email voter should be registered if secrets aren't required" do
+    remove_secrets!
+    voter = RegisterVoter.call(some_valid_email)
+    assert voter.verification_token
+    restore_secrets!
+  end
+
+  def remove_secrets!
+    @voter_secrets = VoterSecret.all.to_a
+    VoterSecret.delete_all
+  end
+
+  def restore_secrets!
+    @voter_secrets.each{ |voter_secret| VoterSecret.create(voter_secret.attributes) }
   end
 end

--- a/test/fixtures/voter_secrets.yml
+++ b/test/fixtures/voter_secrets.yml
@@ -1,0 +1,6 @@
+# Voter secrets
+
+some_voter_secret:
+  data:
+    some_secret: some_value
+    some_another_secret: some_another_value

--- a/test/integration/verification_flow_test.rb
+++ b/test/integration/verification_flow_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class VerificationFlowTest < ActionDispatch::IntegrationTest
   def some_valid_email; "someone@some.tld"; end
+  def some_valid_voter_secret; voter_secrets(:some_voter_secret).data; end
 
   test "should remind the voter to finish the verification process" do
     visit_home!
@@ -92,7 +93,7 @@ class VerificationFlowTest < ActionDispatch::IntegrationTest
   end
 
   def post_registration!(expected_redirect:)
-    post voters_path, params: { voter: {  email: some_valid_email } }
+    post voters_path, params: { voter: {  email: some_valid_email, secret_data: some_valid_voter_secret } }
     assert_redirected_to expected_redirect
     follow_redirect!
     assert_response :success

--- a/test/models/voter_secret_test.rb
+++ b/test/models/voter_secret_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class VoterSecretTest < ActiveSupport::TestCase
+  setup do
+    @voter_secret = VoterSecret.new
+  end
+
+  test "should be valid" do
+    assert @voter_secret.valid?
+  end
+
+  test "may include some data" do
+    assert_not @voter_secret.data?
+    @voter_secret.data = { 'some_key' => 'some_value', 'some_other_key' => 'some_other_value' }
+    assert @voter_secret.data?
+    assert @voter_secret.valid?
+  end
+
+  test "reports the list of secrets" do
+    list_of_secrets = VoterSecret.list_of_secrets
+    assert_equal list_of_secrets_from_fixture_data.sort, list_of_secrets.sort
+  end
+
+  def list_of_secrets_from_fixture_data
+    ['some_secret', 'some_another_secret']
+  end
+end


### PR DESCRIPTION
A `voter_secrets` table has been introduced including a variable payload column, making it possible to configure different requirements for voters validation by storing different payload data.