### PR TITLE
Allow setting a default locale per deployment instance

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,7 +44,7 @@ class ApplicationController < ActionController::Base
   private
 
   def set_locale
-    I18n.locale = params[:locale] || session[:locale] || I18n.default_locale
+    I18n.locale = params[:locale] || session[:locale] || ENV['DEFAULT_LOCALE'] || I18n.default_locale
     session[:locale] = I18n.locale
   end
 


### PR DESCRIPTION
The default locale for a deployment instance can be established now by setting an environment variable `DEFAULT_LOCALE` in the server (e.g. `export DEFAULT_LOCALE=es`).