### PR TITLE
Fix progress bar background color

### DIFF
--- a/app/assets/stylesheets/proposals.scss
+++ b/app/assets/stylesheets/proposals.scss
@@ -18,6 +18,10 @@
       margin-bottom: 0;
     }
 
+    .progress-danger{
+      background-color: $brand-danger;
+    }
+
     .vote-progress-title{
       display: none;
       color: $gray-light;


### PR DESCRIPTION
Due to changes in the Bootstrap components library, the background color for the progress bar danger variation wasn't showed. This is resolved by aliasing the old CSS class and using the current color variable.