### PR TITLE
Update Capistrano deployment definitions

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -41,3 +41,11 @@ task :bundle_pack do
   end
 end
 before 'bundler:install', 'bundle_pack'
+
+# Restarts the application server
+task :application_restart do
+  on roles(:app) do
+    execute :service, fetch(:service_name, "openbudgets"), "restart"
+  end
+end
+before 'deploy:finished', 'application_restart'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -36,7 +36,7 @@ set :bundle_path, "vendor/bundle"
 append :linked_dirs, "vendor/cache", "vendor/bundle"
 
 task :bundle_pack do
-  on roles(:bundle_roles) do
+  on roles(:app) do
     execute "bundle pack --all"
   end
 end


### PR DESCRIPTION
Ensures the execution of the bundle pack task and adds a task to restart the application at the end of the deployment procedure, with the ability of configure the service name used to run the application server.