### PR TITLE
Fix the generation of the label attributes for the voter secret fields

### DIFF
--- a/app/views/voters/new.html.haml
+++ b/app/views/voters/new.html.haml
@@ -12,6 +12,6 @@
               = f.fields_for :secret_data do |df|
                 - VoterSecret.list_of_secrets.each do |secret|
                   .form-group
-                  = df.label _(secret.humanize)
+                  = df.label secret, _(secret.humanize)
                   = df.text_field secret.to_sym, class: 'form-control'
             = f.submit _('Email me a link to sign in'), class: 'btn btn-primary'


### PR DESCRIPTION
The label attributes for the voter secret fields are autogenerated by the Rails `label` helper, but the actual readable text was used as the base value. Now the field code is used instead.