### PR TITLE
Add support to optionally include Google Analytics script

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,6 +12,14 @@
     = csrf_meta_tags
     = stylesheet_link_tag    'application', media: 'all'
     = javascript_include_tag 'application'
+    - if Rails.env.production? and ENV['ANALYTICS_ID']
+      :javascript
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+         })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+         ga('create', '#{ENV['ANALYTICS_ID']}', 'auto');
+         ga('send', 'pageview');
   %body{ class: (scope.blank? ? 'voting' : scope) + ' ' + controller.controller_name + ' ' + controller.action_name }
     .wrapper
       = render 'partials/header'


### PR DESCRIPTION
It includes the Google Analytics tracking script if a Google Analytics key is present in the form of an environment variable (only in production).