### PR TITLE
Use the proper locale when rendering proposal statuses

### DIFF
--- a/app/views/partials/monitoring/_proposal-item.html.haml
+++ b/app/views/partials/monitoring/_proposal-item.html.haml
@@ -7,7 +7,7 @@
     .btn.btn-outline-primary.btn-sm.votes-btn
       = n_('%{votes} vote', '%{votes} votes', proposal.votes) % { votes: proposal.votes }
     %div{ class: 'btn btn-outline-primary btn-sm status-btn status-'+proposal.status.to_s }
-      = proposal.status.to_s.humanize
+      = _(proposal.status.to_s.humanize)
   .card-block.row
     .col-lg-9
       - unless controller.action_name == 'show'


### PR DESCRIPTION
Proposal statuses were being rendered always in the default locale (English). Now the rendering process honors the actual locale being used in the application.