### PR TITLE
Make SMTP configuration generic

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'no-reply@openbudgets.eu'
+  default from: (ENV['MAILER_FROM_ADDRESS'] || 'no-reply@openbudgets.eu')
   layout 'mailer'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,12 +89,12 @@ Rails.application.configure do
 
   # ActionMailer SMTP configuration
   ApplicationMailer.smtp_settings = {
-      address:        'smtp.sendgrid.net',
-      port:           '587',
-      authentication: :plain,
-      user_name:      ENV['SENDGRID_USERNAME'],
-      password:       ENV['SENDGRID_PASSWORD'],
-      domain:         ENV['MTA_DOMAIN'],
-      enable_starttls_auto: true
+      address:        ENV['MAILER_ADDRESS'],
+      port:           ENV['MAILER_PORT'].to_i,
+      authentication: ENV['MAILER_AUTH'].to_sym,
+      user_name:      ENV['MAILER_USERNAME'],
+      password:       ENV['MAILER_PASSWORD'],
+      domain:         ENV['MAILER_DOMAIN'],
+      enable_starttls_auto: (ENV['MAILER_TLS'] == 'true')
   }
 end


### PR DESCRIPTION
Until now the mailer configuration assumed we were using the SendGrid service and a common `no-reply@openbudgets.eu` from email address.

Per pilots request, it seems clear that a more customizable solution is needed, so this make possible to configure the mailer from environment variables entirely.