### PR TITLE
Fix mailer config initialization from environment variables

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,7 +91,7 @@ Rails.application.configure do
   ApplicationMailer.smtp_settings = {
       address:        ENV['MAILER_ADDRESS'],
       port:           ENV['MAILER_PORT'].to_i,
-      authentication: ENV['MAILER_AUTH'].to_sym,
+      authentication: ENV['MAILER_AUTH'],
       user_name:      ENV['MAILER_USERNAME'],
       password:       ENV['MAILER_PASSWORD'],
       domain:         ENV['MAILER_DOMAIN'],


### PR DESCRIPTION
As the mailer support either a symbol or a string value for the authentication setting, the casting to symbol can be removed.