### PR TITLE
Fix proposal creation

### DIFF
--- a/app/controllers/admin/proposals_controller.rb
+++ b/app/controllers/admin/proposals_controller.rb
@@ -23,6 +23,7 @@ class Admin::ProposalsController < AdminController
       redirect_to admin_proposals_path, success: _('Proposal was successfully created.')
     else
       flash.now[:error] = @proposal.errors.full_messages.to_sentence
+      set_classifiers
       render :new
     end
   end

--- a/app/controllers/admin/proposals_controller.rb
+++ b/app/controllers/admin/proposals_controller.rb
@@ -56,7 +56,7 @@ class Admin::ProposalsController < AdminController
   end
 
   def proposal_params
-    p = params.require(:proposal).permit(:title, :description, :budget, :image, :completed, :district_id, :area_id, tag_ids: [])
+    p = params.require(:proposal).permit(:title, :description, :budget, :image, :completed, :campaign_id, :district_id, :area_id, tag_ids: [])
     if p[:budget]
       p[:budget] = p[:budget].gsub(I18n.t('number.currency.format.delimiter'), '_')
       p[:budget] = p[:budget].gsub(I18n.t('number.currency.format.separator'), '.')

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -73,10 +73,12 @@ class Proposal < ApplicationRecord
   end
 
   def chosen?
+    return false if campaign.nil?
     campaign.closed? && campaign.voted_proposals.include?(self)
   end
 
   def discarded?
+    return false if campaign.nil?
     campaign.closed? && !campaign.voted_proposals.include?(self)
   end
 


### PR DESCRIPTION
When creating a proposal from the admin panel the campaign id wasn't properly set, causing an error in the page that lists the existing proposals (#52).

Also, if some kind of error happened when creating a proposal, the system failed to render the form again because the classifiers are not properly initialized.