### PR TITLE
Fix back navigation links

### DIFF
--- a/app/views/admin/proposals/_form.html.haml
+++ b/app/views/admin/proposals/_form.html.haml
@@ -1,7 +1,7 @@
 .voters-new.container
   .row
     .col-lg-8.offset-lg-2
-      %a.btn.btn-outline-primary.btn-sm.back-btn{ href: request.referer, title: _('Back') }
+      %a.btn.btn-outline-primary.btn-sm.back-btn{ href: admin_proposals_path, title: _('Back') }
         = render 'partials/icons/arrow-left'
         = _('Back')
       .card

--- a/app/views/admin/proposals/show.html.haml
+++ b/app/views/admin/proposals/show.html.haml
@@ -1,5 +1,5 @@
 .container
-  %a.btn.btn-outline-primary.btn-sm.back-btn{ href: request.referer, title: _('Back') }
+  %a.btn.btn-outline-primary.btn-sm.back-btn{ href: admin_proposals_path, title: _('Back') }
     = render 'partials/icons/arrow-left'
     = _('Back')
   .proposal

--- a/app/views/monitoring/proposals/show.html.haml
+++ b/app/views/monitoring/proposals/show.html.haml
@@ -1,5 +1,5 @@
 .container
-  %a.btn.btn-outline-primary.btn-sm.back-btn{ href: request.referer, title: _('Back') }
+  %a.btn.btn-outline-primary.btn-sm.back-btn{ href: monitoring_proposals_path, title: _('Back') }
     = render 'partials/icons/arrow-left'
     = _('Back')
   .proposal

--- a/app/views/voting/proposals/show.html.haml
+++ b/app/views/voting/proposals/show.html.haml
@@ -1,5 +1,5 @@
 .container
-  %a.btn.btn-outline-primary.btn-sm.back-btn{ href: request.referer, title: _('Back') }
+  %a.btn.btn-outline-primary.btn-sm.back-btn{ href: voting_proposals_path, title: _('Back') }
     = render 'partials/icons/arrow-left'
     = _('Back')
   .proposal


### PR DESCRIPTION
Currently the 'back' buttons are simply linking to the previous page in the navigation history, but this is producing unexpected results in some cases.

It seems more appropriate for the buttons to link to the previous node in the navigation hierarchy.