### PR TITLE
Update npm project dependencies to support Heroku deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,9 @@
   "scripts": {
     "postinstall": "rollup -c -o vendor/assets/javascripts/d3-bundle.js"
   },
-  "devDependencies": {
-    "rollup": "0.41.6",
-    "rollup-plugin-node-resolve": "3.0.0"
-  },
   "dependencies": {
+    "rollup": "0.41.6",
+    "rollup-plugin-node-resolve": "3.0.0",
     "d3-format": "1.2.0",
     "d3-hierarchy": "1.1.4",
     "d3-scale": "1.0.5",


### PR DESCRIPTION
While in local environments and in server based production ones the rollup library dependencies canbe listed under the 'devDependencies' section of the `package.json` file, that's not the case for Heroku deployments, as the source code is pushed and then built in a remote environment tagged as 'production' by deafult.

Once the rollup usage was introduced, the Heroku deployment process got broken.